### PR TITLE
Add responsive styles and touch drag support

### DIFF
--- a/script.js
+++ b/script.js
@@ -95,10 +95,40 @@ document.addEventListener('DOMContentLoaded', () => {
                 e.target.classList.add('dragging');
             });
 
+            // Support tactile
+            carte.addEventListener('touchstart', (e) => {
+                carteEnCoursDeDrag = e.target;
+                e.target.classList.add('dragging');
+                e.preventDefault();
+            }, { passive: false });
+
             carte.addEventListener('dragend', (e) => {
                 e.target.classList.remove('dragging');
                 carteEnCoursDeDrag = null;
             });
+
+            carte.addEventListener('touchend', (e) => {
+                e.target.classList.remove('dragging');
+                const touch = e.changedTouches[0];
+                const elem = document.elementFromPoint(touch.clientX, touch.clientY);
+                if (elem) {
+                    const cible = elem.closest('.cible');
+                    if (cible && cible.children.length === 0) {
+                        cible.appendChild(carteEnCoursDeDrag);
+                    } else if (elem.closest('#cartes-source')) {
+                        cartesSourceContainer.appendChild(carteEnCoursDeDrag);
+                    }
+
+                    if (cartesCibleContainer.querySelectorAll('.carte').length === ORDRE_CORRECT.length) {
+                        verifierOrdre();
+                    }
+                }
+                carteEnCoursDeDrag = null;
+            });
+
+            carte.addEventListener('touchmove', (e) => {
+                e.preventDefault();
+            }, { passive: false });
         });
 
         // Pour chaque cible...

--- a/style.css
+++ b/style.css
@@ -116,3 +116,31 @@ header {
 #rejouer-btn:hover {
     background-color: #e65100;
 }
+
+@media (max-width: 600px) {
+    .game-container {
+        width: 100%;
+        max-width: none;
+        padding: 15px;
+    }
+
+    .carte,
+    .cible {
+        width: 80px;
+        height: 40px;
+    }
+
+    .carte {
+        padding: 15px 5px;
+        font-size: 0.9rem;
+    }
+
+    header h1 {
+        font-size: 1.2rem;
+    }
+
+    #rejouer-btn {
+        font-size: 14px;
+        padding: 8px 16px;
+    }
+}


### PR DESCRIPTION
## Summary
- adjust layout for small screens with a max-width 600px media query
- shrink cards and fonts on small displays
- add touch event handlers so drag and drop works on mobile

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68504abc60948326b2727717becafb87