### PR TITLE
Add drop validation feedback

### DIFF
--- a/script.js
+++ b/script.js
@@ -115,10 +115,26 @@ document.addEventListener('DOMContentLoaded', () => {
             cible.addEventListener('drop', (e) => {
                 e.preventDefault();
                 e.target.classList.remove('hovered');
-                
+
                 // Si la cible est vide, on y place la carte
                 if (e.target.children.length === 0 && e.target.classList.contains('cible')) {
+                    // Retirer les indicateurs de l'ancienne cible si besoin
+                    const ancienneCible = carteEnCoursDeDrag.parentElement;
+                    if (ancienneCible && ancienneCible.classList.contains('cible')) {
+                        ancienneCible.classList.remove('correct', 'incorrect');
+                    }
+
                     e.target.appendChild(carteEnCoursDeDrag);
+
+                    // Vérifie immédiatement si la carte est bien placée
+                    const attendu = ORDRE_CORRECT[parseInt(e.target.dataset.index, 10)];
+                    if (carteEnCoursDeDrag.id === attendu) {
+                        e.target.classList.add('correct');
+                        e.target.classList.remove('incorrect');
+                    } else {
+                        e.target.classList.add('incorrect');
+                        e.target.classList.remove('correct');
+                    }
                 }
 
                 // Vérifier si toutes les cartes sont placées
@@ -132,6 +148,10 @@ document.addEventListener('DOMContentLoaded', () => {
          cartesSourceContainer.addEventListener('dragover', (e) => e.preventDefault());
          cartesSourceContainer.addEventListener('drop', (e) => {
              e.preventDefault();
+             const ancienneCible = carteEnCoursDeDrag.parentElement;
+             if (ancienneCible && ancienneCible.classList.contains('cible')) {
+                 ancienneCible.classList.remove('correct', 'incorrect');
+             }
              cartesSourceContainer.appendChild(carteEnCoursDeDrag);
          });
     }

--- a/style.css
+++ b/style.css
@@ -92,6 +92,19 @@ header {
     background-color: rgba(255, 255, 255, 0.2);
 }
 
+/* Mise en évidence des placements */
+.cible.correct {
+    border-color: #4caf50;
+    background-color: rgba(76, 175, 80, 0.2);
+    transition: background-color 0.3s, border-color 0.3s;
+}
+
+.cible.incorrect {
+    border-color: #f44336;
+    background-color: rgba(244, 67, 54, 0.2);
+    transition: background-color 0.3s, border-color 0.3s;
+}
+
 /* Style pour les messages de fin de partie */
 .hidden {
     display: none;


### PR DESCRIPTION
## Summary
- evaluate if dropped card matches its slot and mark it correct or incorrect
- show return to deck resets slot highlight
- style correct targets in green, incorrect in red with transitions

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68504abcf2708326961e8d0309ce9b2d