### PR TITLE
Improve card layout and add tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
             <div id="timer">2:00</div>
         </header>
 
-        <div id="cartes-source" class="zone-cartes">
+        <div id="cartes-cible" class="zone-cartes">
             </div>
 
         <div class="separateur"></div>
 
-        <div id="cartes-cible" class="zone-cartes">
+        <div id="cartes-source" class="zone-cartes">
             </div>
 
         <div id="message-fin" class="hidden">

--- a/script.js
+++ b/script.js
@@ -9,9 +9,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Données du Jeu ---
     // Les cartes dans le désordre pour l'affichage initial
-    const CARTES_JEU = ["ESQ", "APS", "APD", "PRO", "EXE", "VISA", "DET", "DOE"];
-    // L'ordre correct pour la vérification
-    const ORDRE_CORRECT = ["ESQ", "APS", "APD", "PRO", "VISA", "EXE", "DET", "DOE"];
+const CARTES_JEU = ["ESQ", "APS", "APD", "PRO", "EXE", "VISA", "DET", "DOE"];
+// L'ordre correct pour la vérification
+const ORDRE_CORRECT = ["ESQ", "APS", "APD", "PRO", "VISA", "EXE", "DET", "DOE"];
+
+    // Noms complets pour l'affichage des info-bulles
+    const NOMS_COMPLETS = {
+        ESQ: 'Esquisse',
+        APS: 'Avant-projet sommaire',
+        APD: 'Avant-projet d\xE9finitif',
+        PRO: 'Projet',
+        VISA: 'Visa',
+        EXE: "\xC9tudes d'ex\xE9cution",
+        DET: "Direction de l'ex\xE9cution des travaux",
+        DOE: 'Dossier des ouvrages ex\xE9cut\xE9s'
+    };
     
     let tempsRestant = 120; // 2 minutes en secondes
     let minuteur;
@@ -50,6 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
             carte.setAttribute('draggable', 'true'); // Indispensable pour le drag-and-drop
             carte.id = nomCarte; // L'id nous servira pour la vérification
             carte.textContent = nomCarte;
+            carte.title = NOMS_COMPLETS[nomCarte] || nomCarte;
             cartesSourceContainer.appendChild(carte);
         });
 

--- a/style.css
+++ b/style.css
@@ -77,8 +77,8 @@ header {
 
 /* Style des emplacements cibles */
 .cible {
-    width: 100px;
-    height: 50px;
+    width: 120px;
+    height: 60px;
     border: 2px dashed rgba(255, 255, 255, 0.5);
     border-radius: 8px;
     display: flex;
@@ -139,8 +139,8 @@ header {
 
     .carte,
     .cible {
-        width: 80px;
-        height: 40px;
+        width: 100px;
+        height: 50px;
     }
 
     .carte {


### PR DESCRIPTION
## Summary
- reorder source cards below target slots
- enlarge target slot size for better usability
- keep responsive layout consistent with new sizes
- add descriptive tooltips for each card

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68504e4945488326b8e4518dabf6442b