### PR TITLE
Add visual score points

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <header>
             <h1>Place les étapes dans l'ordre</h1>
             <div id="timer">2:00</div>
+            <div id="score"></div>
         </header>
 
         <div id="cartes-cible" class="zone-cartes">

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const cartesSourceContainer = document.getElementById('cartes-source');
     const cartesCibleContainer = document.getElementById('cartes-cible');
     const timerElement = document.getElementById('timer');
+    const scoreContainer = document.getElementById('score');
     const messageFinContainer = document.getElementById('message-fin');
     const messageTexteElement = document.getElementById('message-texte');
     const rejouerBtn = document.getElementById('rejouer-btn');
@@ -49,6 +50,7 @@ const ORDRE_CORRECT = ["ESQ", "APS", "APD", "PRO", "VISA", "EXE", "DET", "DOE"];
         // Vider les conteneurs au cas où on rejoue
         cartesSourceContainer.innerHTML = '';
         cartesCibleContainer.innerHTML = '';
+        scoreContainer.innerHTML = '';
         messageFinContainer.classList.add('hidden');
 
         // Mélanger les cartes avant de les afficher
@@ -66,15 +68,36 @@ const ORDRE_CORRECT = ["ESQ", "APS", "APD", "PRO", "VISA", "EXE", "DET", "DOE"];
             cartesSourceContainer.appendChild(carte);
         });
 
-        // Créer les emplacements cibles
+        // Créer les emplacements cibles et les points de score
         ORDRE_CORRECT.forEach((_, index) => {
             const cible = document.createElement('div');
             cible.classList.add('cible');
             cible.dataset.index = index; // On stocke l'index de la cible
             cartesCibleContainer.appendChild(cible);
+
+            const point = document.createElement('div');
+            point.classList.add('point');
+            scoreContainer.appendChild(point);
         });
 
         ajouterListenersDragAndDrop();
+        mettreAJourPoints();
+    }
+
+    /**
+     * Met à jour l'affichage des points en fonction des placements.
+     */
+    function mettreAJourPoints() {
+        const points = scoreContainer.querySelectorAll('.point');
+        const cibles = cartesCibleContainer.querySelectorAll('.cible');
+        cibles.forEach((cible, index) => {
+            const carte = cible.querySelector('.carte');
+            if (carte && carte.id === ORDRE_CORRECT[index]) {
+                points[index].classList.add('correct');
+            } else {
+                points[index].classList.remove('correct');
+            }
+        });
     }
 
     /**
@@ -135,6 +158,7 @@ const ORDRE_CORRECT = ["ESQ", "APS", "APD", "PRO", "VISA", "EXE", "DET", "DOE"];
                     if (cartesCibleContainer.querySelectorAll('.carte').length === ORDRE_CORRECT.length) {
                         verifierOrdre();
                     }
+                    mettreAJourPoints();
                 }
                 carteEnCoursDeDrag = null;
             });
@@ -184,6 +208,7 @@ const ORDRE_CORRECT = ["ESQ", "APS", "APD", "PRO", "VISA", "EXE", "DET", "DOE"];
                 if (cartesCibleContainer.querySelectorAll('.carte').length === ORDRE_CORRECT.length) {
                     verifierOrdre();
                 }
+                mettreAJourPoints();
             });
         });
         
@@ -191,11 +216,12 @@ const ORDRE_CORRECT = ["ESQ", "APS", "APD", "PRO", "VISA", "EXE", "DET", "DOE"];
          cartesSourceContainer.addEventListener('dragover', (e) => e.preventDefault());
          cartesSourceContainer.addEventListener('drop', (e) => {
              e.preventDefault();
-             const ancienneCible = carteEnCoursDeDrag.parentElement;
-             if (ancienneCible && ancienneCible.classList.contains('cible')) {
+            const ancienneCible = carteEnCoursDeDrag.parentElement;
+            if (ancienneCible && ancienneCible.classList.contains('cible')) {
                  ancienneCible.classList.remove('correct', 'incorrect');
              }
              cartesSourceContainer.appendChild(carteEnCoursDeDrag);
+             mettreAJourPoints();
          });
     }
     

--- a/style.css
+++ b/style.css
@@ -36,6 +36,23 @@ header {
     display: inline-block;
 }
 
+#score {
+    margin-top: 10px;
+}
+
+.point {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.4);
+    display: inline-block;
+    margin: 0 2px;
+}
+
+.point.correct {
+    background-color: #4caf50;
+}
+
 .zone-cartes {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- display score placeholders in the header
- style score points and active states
- create `.point` elements for each step
- update points after drop events and board reset

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68505212fee883268ac0c639efeca74b